### PR TITLE
Laravel Glide should be agnostic about the location of the images, th…

### DIFF
--- a/src/GlideImageGenerator.php
+++ b/src/GlideImageGenerator.php
@@ -62,9 +62,9 @@ class GlideImageGenerator
         $imageWidth = $this->getImageWidth($path);
 
         $scale = $scale
-            ->when($maxWidth)->reject(fn (int $width) => $width > $maxWidth)
+            ->when($maxWidth)->reject(fn(int $width) => $width > $maxWidth)
             // We will up-scale an image up to 2x it's original size. Above that it has no use anymore.
-            ->when($imageWidth)->reject(fn (int $width) => $width > ($imageWidth * 2));
+            ->when($imageWidth)->reject(fn(int $width) => $width > ($imageWidth * 2));
 
         // Push a final version with exactly the correct max-width if the difference with the last item
         // in the scale is bigger than 50px. Otherwise, the additional provided type is not so useful.
@@ -76,14 +76,14 @@ class GlideImageGenerator
             ->mapWithKeys(function (int $width) use ($path): array {
                 return [$width => $this->generateUrl($path, ['width' => $width])];
             })
-            ->map(fn (string $src, int $width) => "{$src} {$width}w")
+            ->map(fn(string $src, int $width) => "{$src} {$width}w")
             ->implode(', ');
     }
 
     protected function getImageWidth(string $path): ?int
     {
         return Cache::rememberForever("glide::image-generator.image-width.{$path}", function () use ($path) {
-            return rescue(fn () => Image::make(public_path($path))->width());
+            return rescue(fn() => Image::make($path)->width());
         });
     }
 


### PR DESCRIPTION
…at's up to the dev to determine that.

Sorry for the linting that modifies a lot of lines, the important part is on line 86, I removed the `public_path()` because I could not use Laravel Glide with images stored elsewhere (private directory for example). I guess the path should be explicit, and that's up to the developer to determine that.

Anyway, that package is awesome! 😄 