### PR TITLE
feat: Glide V3 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "illuminate/http": "^10.29|^11.0|^12.0",
         "illuminate/support": "^10.29|^11.0|^12.0",
         "illuminate/view": "^10.29|^11.0|^12.0",
-        "league/glide-symfony": "^2.0",
+        "league/glide": "^3.0",
         "spatie/laravel-package-tools": "^1.14.0"
     },
     "require-dev": {

--- a/src/GlideImageGenerator.php
+++ b/src/GlideImageGenerator.php
@@ -6,7 +6,8 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Str;
 use Illuminate\View\ComponentAttributeBag;
-use Intervention\Image\Facades\Image;
+use Intervention\Image\Drivers\Gd\Driver;
+use Intervention\Image\ImageManager;
 
 class GlideImageGenerator
 {
@@ -94,7 +95,7 @@ class GlideImageGenerator
     protected function getImageWidth(string $path): ?int
     {
         return Cache::rememberForever("glide::image-generator.image-width.{$path}", function () use ($path) {
-            return rescue(fn () => Image::make(public_path($path))->width());
+            return rescue(fn () => $this->imageManager()->read(public_path($path))->width());
         });
     }
 
@@ -108,6 +109,11 @@ class GlideImageGenerator
     protected function isGlideSupported(string $path): bool
     {
         return ! Str::endsWith($path, ['.svg']);
+    }
+
+    protected function imageManager(): ImageManager
+    {
+        return new ImageManager(new Driver());
     }
 
     public function getSourcePath(): string

--- a/src/GlideImageGenerator.php
+++ b/src/GlideImageGenerator.php
@@ -95,7 +95,7 @@ class GlideImageGenerator
     protected function getImageWidth(string $path): ?int
     {
         return Cache::rememberForever("glide::image-generator.image-width.{$path}", function () use ($path) {
-            return rescue(fn () => $this->imageManager()->read(public_path($path))->width());
+            return rescue(fn () => $this->getImageManager()->read(public_path($path))->width());
         });
     }
 
@@ -111,9 +111,9 @@ class GlideImageGenerator
         return ! Str::endsWith($path, ['.svg']);
     }
 
-    protected function imageManager(): ImageManager
+    protected function getImageManager(): ImageManager
     {
-        return new ImageManager(new Driver());
+        return ImageManager::gd();
     }
 
     public function getSourcePath(): string

--- a/src/GlideImageGenerator.php
+++ b/src/GlideImageGenerator.php
@@ -6,8 +6,8 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Str;
 use Illuminate\View\ComponentAttributeBag;
-use Intervention\Image\Drivers\Gd\Driver;
 use Intervention\Image\ImageManager;
+use RuntimeException;
 
 class GlideImageGenerator
 {
@@ -113,7 +113,15 @@ class GlideImageGenerator
 
     protected function getImageManager(): ImageManager
     {
-        return ImageManager::gd();
+        if (extension_loaded('gd')) {
+            return ImageManager::gd();
+        }
+
+        if (extension_loaded('imagick')) {
+            return ImageManager::imagick();
+        }
+
+        throw new RuntimeException('No supported image driver (GD or Imagick) is installed.');
     }
 
     public function getSourcePath(): string

--- a/src/Http/Controllers/GlideController.php
+++ b/src/Http/Controllers/GlideController.php
@@ -6,8 +6,8 @@ use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Http\Request;
 use League\Glide\Filesystem\FileNotFoundException;
-use RalphJSmit\Laravel\Glide\Responses\ResponseFactory;
 use League\Glide\ServerFactory;
+use RalphJSmit\Laravel\Glide\Http\Controllers\GlideController\GlideResponseFactory;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class GlideController
@@ -17,7 +17,7 @@ class GlideController
         $source = $source ?? $domainOrSource;
 
         $server = ServerFactory::create([
-            'response' => new ResponseFactory($request),
+            'response' => new GlideResponseFactory($request),
             'source' => glide()->getSourcePath(),
             'cache' => glide()->getCachePath(),
             'base_url' => '',

--- a/src/Http/Controllers/GlideController.php
+++ b/src/Http/Controllers/GlideController.php
@@ -6,7 +6,7 @@ use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Http\Request;
 use League\Glide\Filesystem\FileNotFoundException;
-use League\Glide\Responses\SymfonyResponseFactory;
+use RalphJSmit\Laravel\Glide\Responses\ResponseFactory;
 use League\Glide\ServerFactory;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
@@ -17,7 +17,7 @@ class GlideController
         $source = $source ?? $domainOrSource;
 
         $server = ServerFactory::create([
-            'response' => new SymfonyResponseFactory($request),
+            'response' => new ResponseFactory($request),
             'source' => glide()->getSourcePath(),
             'cache' => glide()->getCachePath(),
             'base_url' => '',

--- a/src/Http/Controllers/GlideController/GlideResponseFactory.php
+++ b/src/Http/Controllers/GlideController/GlideResponseFactory.php
@@ -1,20 +1,17 @@
 <?php
 
-namespace RalphJSmit\Laravel\Glide\Responses;
+namespace RalphJSmit\Laravel\Glide\Http\Controllers\GlideController;
 
 use League\Flysystem\FilesystemOperator;
 use League\Glide\Responses\ResponseFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
-class ResponseFactory implements ResponseFactoryInterface
+class GlideResponseFactory implements ResponseFactoryInterface
 {
-    protected ?Request $request;
-
-    public function __construct(?Request $request = null)
-    {
-        $this->request = $request;
-    }
+    public function __construct(
+        protected ?Request $request = null
+    ) {}
 
     public function create(FilesystemOperator $cache, string $path): StreamedResponse
     {

--- a/src/Responses/ResponseFactory.php
+++ b/src/Responses/ResponseFactory.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace RalphJSmit\Laravel\Glide\Responses;
+
+use League\Flysystem\FilesystemOperator;
+use League\Glide\Responses\ResponseFactoryInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class ResponseFactory implements ResponseFactoryInterface
+{
+    protected ?Request $request;
+
+    public function __construct(?Request $request = null)
+    {
+        $this->request = $request;
+    }
+
+    public function create(FilesystemOperator $cache, string $path): StreamedResponse
+    {
+        $stream = $cache->readStream($path);
+
+        $response = new StreamedResponse();
+        $response->headers->set('Content-Type', $cache->mimeType($path));
+        $response->headers->set('Content-Length', $cache->fileSize($path));
+        $response->setPublic();
+        $response->setMaxAge(31536000);
+        $response->setExpires(date_create()->modify('+1 years'));
+
+        if ($this->request) {
+            $response->setLastModified(date_create()->setTimestamp($cache->lastModified($path)));
+            $response->isNotModified($this->request);
+        }
+
+        $response->setCallback(function () use ($stream) {
+            if (ftell($stream) !== 0) {
+                rewind($stream);
+            }
+            fpassthru($stream);
+            fclose($stream);
+        });
+
+        return $response;
+    }
+}


### PR DESCRIPTION
Hi,

I’ve added support for Glide v3, which now uses **Image Intervention v3**.

I avoided using the `league/glide-symfony` package because it’s stuck on **Image Intervention v2** and there are unmerged [PRs](https://github.com/thephpleague/glide-symfony/pulls). Instead, I used `league/glide` directly and implemented the **_ResponseFactory_** within this package.

I think this should become a new major version of the `laravel-glide` package, so it can fully support users running **Image Intervention v3** in their Laravel applications.