### PR TITLE
feat: add Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
     ],
     "require": {
         "php": "^8.1",
-        "illuminate/contracts": "^10.0|^11.0|^12.0",
-        "illuminate/http": "^10.29|^11.0|^12.0",
-        "illuminate/support": "^10.29|^11.0|^12.0",
-        "illuminate/view": "^10.29|^11.0|^12.0",
+        "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/http": "^10.29|^11.0|^12.0|^13.0",
+        "illuminate/support": "^10.29|^11.0|^12.0|^13.0",
+        "illuminate/view": "^10.29|^11.0|^12.0|^13.0",
         "league/glide": "^3.0",
         "spatie/laravel-package-tools": "^1.14.0"
     },


### PR DESCRIPTION
Updates the `illuminate/*` dependency constraints to include ^13.0, allowing this package to be used with Laravel 13.