### PR TITLE
feat: configurable `grow` via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,15 @@ This will **empty the entire Glide cache**. You can choose to put this in your d
 
 ## Glide Configuration
 
-Currently, the package **does not provide configuration** options and it just assumes **sensible defaults**.
+Currently, the package **does not provide advanced configuration** options and it just assumes **sensible defaults**.
+
+If you want to modify the basic configuration values, you can publish the config file:
+
+```bash
+php artisan vendor:publish --tag=glide-config
+```
+
+After publishing, you can modify the configuration in `config/glide.php`.
 
 Since it is geared at auto-generating versions for static images, it will **assume** the `public_path()`/`asset()` as root folder for the images.
 

--- a/config/glide.php
+++ b/config/glide.php
@@ -23,4 +23,6 @@ return [
          */
         'signed' => false,
     ],
+
+    'grow' => false,
 ];

--- a/config/glide.php
+++ b/config/glide.php
@@ -9,6 +9,29 @@ return [
      */
     'default_source_disk' => null,
 
+    'route' => [
+        /**
+         * The domain that will be used to generate the Glide URLs.
+         */
+        'domain' => null,
+
+        /**
+         * Whether the generated Glide URLs should be signed.
+         * For some browsers this differing query string
+         * might prevent browser caching of the image,
+         * but major browsers appear to handle fine.
+         */
+        'signed' => false,
+    ],
+
+    /**
+     * By default, images receive a `max-width: {originalImageWidth}` rule,
+     * so that CSS will not upscale them beyond their original width. This
+     * can be overridden on a per-image basis using the `grow` function
+     * parameter. However, it can also be configured globally here.
+     */
+    'grow' => false,
+
     /**
      * The default image scales to generate.
      */
@@ -29,23 +52,6 @@ return [
         9000,
         10000,
     ],
-
-    'route' => [
-        /**
-         * The domain that will be used to generate the Glide URLs.
-         */
-        'domain' => null,
-
-        /**
-         * Whether the generated Glide URLs should be signed.
-         * For some browsers this differing query string
-         * might prevent browser caching of the image,
-         * but major browsers appear to handle fine.
-         */
-        'signed' => false,
-    ],
-
-    'grow' => false,
 
     /**
      * By default, upscaling is enabled up to 2x the original image size.

--- a/src/GlideImageGenerator.php
+++ b/src/GlideImageGenerator.php
@@ -15,9 +15,11 @@ use RuntimeException;
 
 class GlideImageGenerator
 {
-    public function src(string $path, ?int $maxWidth = null, ?string $sizes = null, bool $lazy = true, bool $grow = false, ?string $disk = null): ComponentAttributeBag
+    public function src(string $path, ?int $maxWidth = null, ?string $sizes = null, bool $lazy = true, ?bool $grow = null, ?string $disk = null): ComponentAttributeBag
     {
         $attributes = new ComponentAttributeBag();
+
+        $grow = $grow ?? config('glide.grow');
 
         $isGlideSupported = $this->isGlideSupported($path);
 


### PR DESCRIPTION
Added the ability to set `grow` in config file.

For sites where you never want to add the max-width inline css to the responsive images this is really useful.