### PR TITLE
fix: include original image size in `srcset` when larger than largest scale

### DIFF
--- a/src/GlideImageGenerator.php
+++ b/src/GlideImageGenerator.php
@@ -94,8 +94,20 @@ class GlideImageGenerator
             $scale->push($maxWidth);
         }
 
+        // Push the exact image width if it's larger than the last scale item,
+        // so the image isn't served smaller than the original.
+        // Only do this if the difference with the last item is bigger than 50px.
+        // Otherwise, the additional provided type is not so useful.
+        if ($imageWidth && ($imageWidth - $scale->last()) > 50) {
+            $scale->push($imageWidth);
+        }
+
         return $scale
-            ->mapWithKeys(function (int $width) use ($path, $disk): array {
+            ->mapWithKeys(function (int $width) use ($path, $disk, $imageWidth): array {
+                if ($imageWidth && $width === $imageWidth) {
+                    return [$width => asset($path)];
+                }
+
                 return [$width => $this->generateUrl($path, ['width' => $width], $disk)];
             })
             ->map(fn (string $src, int $width) => "{$src} {$width}w")

--- a/src/GlideImageGenerator.php
+++ b/src/GlideImageGenerator.php
@@ -94,10 +94,9 @@ class GlideImageGenerator
             $scale->push($maxWidth);
         }
 
-        // Push the exact image width if it's larger than the last scale item,
-        // so the image isn't served smaller than the original.
-        // Only do this if the difference with the last item is bigger than 50px.
-        // Otherwise, the additional provided type is not so useful.
+        // We will push the exact original image width onto the scale so the image is never served
+        // smaller than its source. We only do this when the difference with the last item is bigger
+        // than 50px. Otherwise, the additional provided source is not so useful.
         if ($imageWidth && ($imageWidth - $scale->last()) > 50) {
             $scale->push($imageWidth);
         }


### PR DESCRIPTION
Push exact original image size if the last scale item is much smaller (more than 50px difference between the latest srcset scale).

Serve the original image in this case to avoid regenerating the image in its original size in the cache folder.