### PR TITLE
fix: encode spaces within generated file names

### DIFF
--- a/src/GlideImageGenerator.php
+++ b/src/GlideImageGenerator.php
@@ -96,6 +96,10 @@ class GlideImageGenerator
 
         return $scale
             ->mapWithKeys(function (int $width) use ($path, $disk): array {
+                // Replace spaces in generated file names to URL encoded strings (%20).
+                // File names containing spaces doesn't work with Glide without this.
+                $path = str_replace(' ', '%20', $path);
+
                 return [$width => $this->generateUrl($path, ['width' => $width], $disk)];
             })
             ->map(fn (string $src, int $width) => "{$src} {$width}w")

--- a/src/GlideImageGenerator.php
+++ b/src/GlideImageGenerator.php
@@ -96,9 +96,9 @@ class GlideImageGenerator
 
         return $scale
             ->mapWithKeys(function (int $width) use ($path, $disk): array {
-                // Replace spaces in generated file names to URL encoded strings (%20).
-                // File names containing spaces doesn't work with Glide without this.
-                $path = str_replace(' ', '%20', $path);
+                // URL-encode each path segment so special characters (spaces, #, ?, &, etc.)
+                // in file names work with Glide. We encode per-segment to preserve the slashes.
+                $path = implode('/', array_map('rawurlencode', explode('/', $path)));
 
                 return [$width => $this->generateUrl($path, ['width' => $width], $disk)];
             })


### PR DESCRIPTION
Replace spaces in generated file names to URL encoded strings.
File names containing spaces doesn't work with Glide without this.